### PR TITLE
Feature/update

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -11,3 +11,21 @@ VALUES (3, 'Pikachu', '2021-01-07', 1, false, 15.04);
 
 INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
 VALUES (4, 'Devimon', '2017-05-12', 5, true, 11);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (5, 'Charmander', '2020-02-08', 0, false, -11);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (6, 'Plantmon', '2022-11-15', 2, true, -5.7);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (7, 'Squirtle', '1993-04-02', 3, false, -12.13);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (8, 'Angemon', '2005-06-12', 1, true, -45);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (9, 'Boarmon', '2005-06-07', 7, true, 20.4);
+
+INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
+VALUES (10, 'Blossom', '1998-10-13', 3, true, 17);

--- a/data.sql
+++ b/data.sql
@@ -32,8 +32,6 @@ VALUES (10, 'Blossom', '1998-10-13', 3, true, 17);
 
 BEGIN TRANSACTION; -- start transaction
 
-UPDATE animals SET species = 'unspecified';
-
 -- Undo changes
 ROLLBACK;
 
@@ -42,12 +40,8 @@ SELECT * FROM animals;
 
 BEGIN;
 
-UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
-
 -- Verify that the species column got updated
 SELECT name, species FROM animals;
-
-UPDATE animals SET species = 'pokemon' WHERE species IS NULL;
 
 COMMIT;
 
@@ -68,10 +62,6 @@ DELETE FROM animals WHERE date_of_birth > 'Jan 1, 2022';
 
 SAVEPOINT SPECIES;
 
-UPDATE animals SET weight_kg = weight_kg * -1;
-
 ROLLBACK TO SPECIES;
-
-UPDATE animals SET weight_kg = weight_kg * -1 WHERE weight_kg < 0;
 
 COMMIT TRANSACTION;

--- a/data.sql
+++ b/data.sql
@@ -34,9 +34,6 @@ BEGIN TRANSACTION; -- start transaction
 
 UPDATE animals SET species = 'unspecified';
 
---verify the changes were made
-SELECT * FROM animals;
-
 -- Undo changes
 ROLLBACK;
 

--- a/data.sql
+++ b/data.sql
@@ -63,4 +63,12 @@ BEGIN;
 
 DELETE FROM animals WHERE date_of_birth > 'Jan 1, 2022';
 
-SAVE TRANSACTION sp1;
+SAVEPOINT SPECIES;
+
+UPDATE animals SET weight_kg = weight_kg * -1;
+
+ROLLBACK TO SPECIES;
+
+UPDATE animals SET weight_kg = weight_kg * -1 WHERE weight_kg < 0;
+
+COMMIT TRANSACTION;

--- a/data.sql
+++ b/data.sql
@@ -29,3 +29,38 @@ VALUES (9, 'Boarmon', '2005-06-07', 7, true, 20.4);
 
 INSERT INTO animals (id, name, date_of_birth, escape_attempts, neutered, weight_kg)  
 VALUES (10, 'Blossom', '1998-10-13', 3, true, 17);
+
+BEGIN TRANSACTION; -- start transaction
+
+-- sets all items/rows in the species column to unspecified
+UPDATE animals SET species = 'unspecified';
+
+--verify the changes were made
+SELECT * FROM animals;
+
+-- Undo changes, species column is now empty
+ROLLBACK;
+
+BEGIN;
+
+UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
+
+UPDATE animals SET species = 'pokemon' WHERE species IS NULL;
+
+COMMIT;
+
+SELECT name, species FROM animals;
+
+BEGIN;
+
+DELETE FROM animals;
+
+ROLLBACK;
+
+SELECT * FROM animals;
+
+BEGIN;
+
+DELETE FROM animals WHERE date_of_birth > 'Jan 1, 2022';
+
+SAVE TRANSACTION sp1;

--- a/data.sql
+++ b/data.sql
@@ -32,23 +32,29 @@ VALUES (10, 'Blossom', '1998-10-13', 3, true, 17);
 
 BEGIN TRANSACTION; -- start transaction
 
--- sets all items/rows in the species column to unspecified
 UPDATE animals SET species = 'unspecified';
 
 --verify the changes were made
 SELECT * FROM animals;
 
--- Undo changes, species column is now empty
+-- Undo changes
 ROLLBACK;
+
+--verify whether the species column went back to how it was before the update
+SELECT * FROM animals;
 
 BEGIN;
 
 UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
 
+-- Verify that the species column got updated
+SELECT name, species FROM animals;
+
 UPDATE animals SET species = 'pokemon' WHERE species IS NULL;
 
 COMMIT;
 
+-- Verify that change was made and persists after commit.
 SELECT name, species FROM animals;
 
 BEGIN;

--- a/queries.sql
+++ b/queries.sql
@@ -15,3 +15,13 @@ SELECT neutered, MIN(weight_kg), MAX(weight_kg) FROM animals GROUP BY neutered;
 /* Average number of escape attempts per animal type of those born between 1990 and 2000 */
 SELECT neutered, AVG(escape_attempts) FROM animals WHERE date_of_birth 
 BETWEEN 'Jan 1, 1990' AND 'Dec 31, 2000' GROUP BY neutered;
+
+UPDATE animals SET species = 'unspecified';
+
+UPDATE animals SET species = 'digimon' WHERE name LIKE '%mon';
+
+UPDATE animals SET species = 'pokemon' WHERE species IS NULL;
+
+UPDATE animals SET weight_kg = weight_kg * -1;
+
+UPDATE animals SET weight_kg = weight_kg * -1 WHERE weight_kg < 0;

--- a/queries.sql
+++ b/queries.sql
@@ -1,17 +1,17 @@
 /*Queries that provide answers to the questions from all projects.*/
 
-SELECT * from animals WHERE name LIKE '%mon';
+SELECT COUNT(*) FROM animals;
 
-SELECT name FROM animals WHERE date_of_birth BETWEEN '2016-01-01' AND '2019-01-01';
+SELECT COUNT(*) FROM animals WHERE escape_attempts = 0;
 
-SELECT name FROM animals WHERE neutered = TRUE AND escape_attempts < 3;
+SELECT AVG(weight_kg) FROM animals;
 
-SELECT date_of_birth FROM animals WHERE name = 'Agumon' OR  name = 'Pikachu';
+/* Sum escape attempts and compare between neutered and non-neutered */
+SELECT neutered, SUM(escape_attempts) FROM animals GROUP BY neutered;
 
-SELECT name, escape_attempts FROM animals WHERE weight_kg < 10.5;
+/* Minimum and maximum weights of each type of animal*/
+SELECT neutered, MIN(weight_kg), MAX(weight_kg) FROM animals GROUP BY neutered;
 
-SELECT *  FROM animals WHERE neutered = TRUE;
-
-SELECT *  FROM animals WHERE name <> 'Gabumon';
-
-SELECT * FROM animals WHERE weight_kg >=10.4 AND weight_kg <=17.3;
+/* Average number of escape attempts per animal type of those born between 1990 and 2000 */
+SELECT neutered, AVG(escape_attempts) FROM animals WHERE date_of_birth 
+BETWEEN 'Jan 1, 1990' AND 'Dec 31, 2000' GROUP BY neutered;

--- a/schema.sql
+++ b/schema.sql
@@ -8,3 +8,6 @@ CREATE TABLE animals(
    neutered boolean,
    weight_kg decimal
 );
+
+ALTER TABLE animals 
+ADD COLUMN species VARCHAR;


### PR DESCRIPTION
- Add column species to the animals table
- Insert values to the animals table
- Inside a transaction update the animals table by setting the species column to unspecified
- Inside a transaction: Update the animals table by setting the species column to digimon for all animals that have a name ending in mon and Update the animals table by setting the species column to pokemon for all animals that don't have species already set. Commit the transaction.
- Inside a transaction delete all records in the animals table, then roll back the transaction.
- Inside a transaction: Delete all animals born after Jan 1st, 2022. Create a savepoint for the transaction. Update all animals' weight to be their weight multiplied by -1. Rollback to the savepoint. Update all animals' weights that are negative to be their weight multiplied by -1. Commit transaction
- Write queries to the animals table.